### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## GitHub Pages Deployment
+
+This project is configured to deploy using GitHub Actions. When changes are pushed to the `main` branch, the site is built and published to the `gh-pages` branch automatically. The published site is available at `https://<your-account>.github.io/sappi-web/`.
+
+To trigger a manual deployment run:
+
+```bash
+npm run build
+```
+
+and commit the generated `dist` folder to the `gh-pages` branch or rely on the included workflow.

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; URL=/sappi-web/" />
+    <title>Redirecting...</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href="/sappi-web/">/sappi-web/</a></p>
+  </body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig(({ mode }) => ({
   plugins: [react()],
-  base: mode === 'production' ? '/sappi-web' : '/',
+  base: mode === 'production' ? '/sappi-web/' : '/',
 }));
 
 


### PR DESCRIPTION
## Summary
- set `base` for Vite production builds
- add GitHub Actions workflow to deploy to Pages
- add 404 redirect page for SPA routing
- document deployment steps in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bfdba3a088323bbf93ec966d85622