### PR TITLE
Fix asset paths for GH Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./main.jsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="sappi-web/src/main.jsx"></script>
+    <script type="module" src="/sappi-web/src/main.jsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="sappi-web/main.jsx"></script>
+    <script type="module" src="sappi-web/src/main.jsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./main.jsx"></script>
+    <script type="module" src="sappi-web/main.jsx"></script>
   </body>
 </html>

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -1,12 +1,13 @@
 // src/Footer.jsx
 export default function Footer() {
+    const base = import.meta.env.BASE_URL;
     return (
       <footer className="site-footer">
         <div className="footer-content">
           <div className="footer-links">
-            <a href="/about">このサイトについて</a>
-            <a href="/goods">ギャラリー一覧</a>
-            <a href="/ContactForm">お問い合わせ</a>
+            <a href={`${base}about`}>このサイトについて</a>
+            <a href={`${base}goods`}>ギャラリー一覧</a>
+            <a href={`${base}ContactForm`}>お問い合わせ</a>
           </div>
           <div className="footer-sns">
             <a href="https://twitter.com/your_twitter" target="_blank" rel="noopener" aria-label="X (Twitter)">

--- a/src/components/FairyTypingAnimation.jsx
+++ b/src/components/FairyTypingAnimation.jsx
@@ -56,7 +56,7 @@ export default function FairyTypingAnimation() {
         <TypingText onUpdatePos={setCurrentChar} fairyPos={fairyPos} />
         {/* 妖精キャラ画像 */}
         <img
-          src="/fairy.png"
+          src={`${import.meta.env.BASE_URL}fairy.png`}
           alt="妖精"
           className="fairy-char"
           style={{

--- a/src/components/NavCards.jsx
+++ b/src/components/NavCards.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import WorksCarousel from "./WorksCarousel.jsx";
 
+const base = import.meta.env.BASE_URL;
 const navItems = [
   {
     title: "ギャラリー一覧",
@@ -29,7 +30,7 @@ export default function NavCards() {
     <section className="nav-cards">
       {navItems.map((item,i) => (
         <motion.a
-         href={item.link} 
+         href={`${base}${item.link.replace(/^\//, "")}`}
          className="nav-card" 
          key={item.title}
          initial={{ opacity: 0, y: 40 }}

--- a/src/components/SplashAnimation.jsx
+++ b/src/components/SplashAnimation.jsx
@@ -1,46 +1,48 @@
 import { useState, useEffect , useRef} from "react";
 
+const base = import.meta.env.BASE_URL;
+
 const images = [
-  "/public/split_(156x170)/image_(1-1).png",
-//   "/public/split_(156x170)/image_(1-2).png",
-//   "/public/split_(156x170)/image_(1-3).png",
-  "/public/split_(156x170)/image_(1-4).png",
-//   "/public/split_(156x170)/image_(1-5).png",
-  "/public/split_(156x170)/image_(1-6).png",
-//   "/public/split_(156x170)/image_(2-1).png",
-  "/public/split_(156x170)/image_(2-2).png",
-//   "/public/split_(156x170)/image_(2-3).png",
-  "/public/split_(156x170)/image_(2-4).png",
-  "/public/split_(156x170)/image_(2-5).png",
-  "/public/split_(156x170)/image_(2-6).png",
-  "/public/split_(156x170)/image_(3-1).png",
-  "/public/split_(156x170)/image_(3-2).png",
-  "/public/split_(156x170)/image_(3-3).png",
-  "/public/split_(156x170)/image_(3-4).png",
-  "/public/split_(156x170)/image_(3-5).png",
-  "/public/split_(156x170)/image_(3-6).png",
-  "/public/split_(156x170)/image_(4-2).png",
-  "/public/split_(156x170)/image_(4-3).png",
-  "/public/split_(156x170)/image_(4-5).png",
-  "/public/split_(156x170)/image_(4-6).png",
-  "/public/split_(156x170)/image_(5-1).png",
-  "/public/split_(156x170)/image_(5-2).png",
-  "/public/split_(156x170)/image_(5-3).png",
-  "/public/split_(156x170)/image_(5-4).png",
-  "/public/split_(156x170)/image_(5-5).png",
-  "/public/split_(156x170)/image_(5-6).png",
-  "/public/split_(156x170)/image_(4-2).png",
-  "/public/split_(156x170)/image_(4-3).png",
-  "/public/split_(156x170)/image_(4-5).png",
-  "/public/split_(156x170)/image_(4-6).png",
-  "/public/split_(156x170)/image_(5-1).png",
-  "/public/split_(156x170)/image_(5-2).png",
-  "/public/split_(156x170)/image_(5-3).png",
-  "/public/split_(156x170)/image_(5-4).png",
-  "/public/split_(156x170)/image_(5-5).png",
-  "/public/split_(156x170)/image_(5-6).png",
+  "split_(156x170)/image_(1-1).png",
+  // "split_(156x170)/image_(1-2).png",
+  // "split_(156x170)/image_(1-3).png",
+  "split_(156x170)/image_(1-4).png",
+  // "split_(156x170)/image_(1-5).png",
+  "split_(156x170)/image_(1-6).png",
+  // "split_(156x170)/image_(2-1).png",
+  "split_(156x170)/image_(2-2).png",
+  // "split_(156x170)/image_(2-3).png",
+  "split_(156x170)/image_(2-4).png",
+  "split_(156x170)/image_(2-5).png",
+  "split_(156x170)/image_(2-6).png",
+  "split_(156x170)/image_(3-1).png",
+  "split_(156x170)/image_(3-2).png",
+  "split_(156x170)/image_(3-3).png",
+  "split_(156x170)/image_(3-4).png",
+  "split_(156x170)/image_(3-5).png",
+  "split_(156x170)/image_(3-6).png",
+  "split_(156x170)/image_(4-2).png",
+  "split_(156x170)/image_(4-3).png",
+  "split_(156x170)/image_(4-5).png",
+  "split_(156x170)/image_(4-6).png",
+  "split_(156x170)/image_(5-1).png",
+  "split_(156x170)/image_(5-2).png",
+  "split_(156x170)/image_(5-3).png",
+  "split_(156x170)/image_(5-4).png",
+  "split_(156x170)/image_(5-5).png",
+  "split_(156x170)/image_(5-6).png",
+  "split_(156x170)/image_(4-2).png",
+  "split_(156x170)/image_(4-3).png",
+  "split_(156x170)/image_(4-5).png",
+  "split_(156x170)/image_(4-6).png",
+  "split_(156x170)/image_(5-1).png",
+  "split_(156x170)/image_(5-2).png",
+  "split_(156x170)/image_(5-3).png",
+  "split_(156x170)/image_(5-4).png",
+  "split_(156x170)/image_(5-5).png",
+  "split_(156x170)/image_(5-6).png",
   // ...必要な枚数分追加（/publicに置くとパスだけでOK）
-];
+].map(p => `${base}${p}`);
 
 const crackFrames = [0];
 
@@ -65,7 +67,7 @@ function SplashAnimation({ onFinish }) {
 
   return (
     <div className="splash-bg">
-    <audio ref={audioRef} src="/audio/孵化・卵孵る.mp3" preload="auto" />
+    <audio ref={audioRef} src={`${base}audio/孵化・卵孵る.mp3`} preload="auto" />
       <img
         src={images[frame]}
         alt={`アニメ${frame + 1}`}

--- a/src/components/WorksCarousel.jsx
+++ b/src/components/WorksCarousel.jsx
@@ -81,10 +81,11 @@
 import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 
+const base = import.meta.env.BASE_URL;
 const images = [
-  { src: "/sappi-1.jpg", alt: "森の中のどうぶつたち", title: "森の中のどうぶつたち" },
-  { src: "/sappi-2.jpeg", alt: "夜空のぼうけん", title: "夜空のぼうけん" },
-  { src: "/sappi-3.jpeg", alt: "おひさまとおはな", title: "おひさまとおはな" },
+  { src: `${base}sappi-1.jpg`, alt: "森の中のどうぶつたち", title: "森の中のどうぶつたち" },
+  { src: `${base}sappi-2.jpeg`, alt: "夜空のぼうけん", title: "夜空のぼうけん" },
+  { src: `${base}sappi-3.jpeg`, alt: "おひさまとおはな", title: "おひさまとおはな" },
 ];
 
 export default function WorksCarousel() {

--- a/src/main1.jsx
+++ b/src/main1.jsx
@@ -12,13 +12,14 @@ import WorksCarousel from "./components/WorksCarousel";
 import "./index.css";
 import "./App.css";
 
+const base = import.meta.env.BASE_URL;
 const images = [
-  { src: "/sappi-1.jpg", alt: "森の中のどうぶつたち" },
-  { src: "/sappi-2.jpeg", alt: "夜空のぼうけん" },
-  { src: "/sappi-3.jpeg", alt: "おひさまとおはな" },
-  { src: "/sappi-3.jpeg", alt: "おひさまとおはな" },
-  { src: "/sappi-3.jpeg", alt: "おひさまとおはな" },
-  { src: "/sappi-3.jpeg", alt: "おひさまとおはな" },
+  { src: `${base}sappi-1.jpg`, alt: "森の中のどうぶつたち" },
+  { src: `${base}sappi-2.jpeg`, alt: "夜空のぼうけん" },
+  { src: `${base}sappi-3.jpeg`, alt: "おひさまとおはな" },
+  { src: `${base}sappi-3.jpeg`, alt: "おひさまとおはな" },
+  { src: `${base}sappi-3.jpeg`, alt: "おひさまとおはな" },
+  { src: `${base}sappi-3.jpeg`, alt: "おひさまとおはな" },
 ];
 
 


### PR DESCRIPTION
## Summary
- ensure images and audio use `import.meta.env.BASE_URL`
- update navigation links to use repository base
- switch footer links to use repo base

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c0580aacc8323b3dcbd16f9524120